### PR TITLE
Add dynamic case studies section

### DIFF
--- a/src/components/sections/Cases.astro
+++ b/src/components/sections/Cases.astro
@@ -1,31 +1,10 @@
 ---
-import { Image } from "astro:assets";
-import Card from "../ui/Card.astro";
 import Section from "./Section.astro";
-
-const cards = [
-  {
-    index: 0,
-    title:
-      "For a local restaurant, we implemented a targeted PPC campaign that resulted in a 50% increase in website traffic and a 25% increase in sales.",
-    link: "https://google.com",
-  },
-  {
-    index: 1,
-    title:
-      "For a B2B software company, we developed an SEO strategy that resulted in a first page ranking for key keywords and a 200% increase in organic traffic.",
-    link: "https://google.com",
-  },
-  {
-    index: 1,
-    title:
-      "For a national retail chain, we created a social media marketing campaign that increased followers by 25% and generated a 20% increase in online sales.",
-    link: "https://google.com",
-  },
-];
-
-import larrow from "../../assets/icon3.svg";
 import SectionTitle from "../ui/SectionTitle.astro";
+import { getCollection } from 'astro:content';
+import CaseCard from "../ui/CaseCard.astro";
+
+const cases = await getCollection('cases');
 ---
 
 <Section id="cases">
@@ -35,20 +14,8 @@ import SectionTitle from "../ui/SectionTitle.astro";
   />
   <div class="flex flex-col lg:flex-row justify-between p-1">
     {
-      cards.map((card) => (
-        <Card>
-          <div class="flex p-[60px] h-full bg-dark text-gray m-[1px]">
-            <div class="flex flex-col gap-5">
-              <p>{card.title}</p>
-              <a href={card.link} class="flex items-center gap-[15px]">
-                <span class="text-orange">Case Info</span>
-                <picture>
-                  <Image src={larrow} alt="Arrow pointing up right" />
-                </picture>
-              </a>
-            </div>
-          </div>
-        </Card>
+      cases.map((cs) => (
+        <CaseCard summary={cs.data.summary} link={'/case-studies/' + cs.slug} />
       ))
     }
   </div>

--- a/src/components/ui/CaseCard.astro
+++ b/src/components/ui/CaseCard.astro
@@ -1,0 +1,20 @@
+---
+import { Image } from "astro:assets";
+import Card from "./Card.astro";
+import larrow from "../../assets/icon3.svg";
+
+const { summary, link } = Astro.props;
+---
+<Card>
+  <div class="flex p-[60px] h-full bg-dark text-gray m-[1px] intersect-once intersect:motion-preset-slide-up">
+    <div class="flex flex-col gap-5">
+      <p>{summary}</p>
+      <a href={link} class="flex items-center gap-[15px]">
+        <span class="text-orange">Case Info</span>
+        <picture>
+          <Image src={larrow} alt="Arrow pointing up right" />
+        </picture>
+      </a>
+    </div>
+  </div>
+</Card>

--- a/src/content/cases/b2b-seo-strategy.md
+++ b/src/content/cases/b2b-seo-strategy.md
@@ -1,0 +1,7 @@
+---
+title: "B2B SEO Strategy"
+summary: "For a B2B software company, we developed an SEO strategy that resulted in a first page ranking for key keywords and a 200% increase in organic traffic."
+link: "https://google.com"
+---
+
+Deep keyword research and technical optimisation paved the way for sustained growth. Quality content and outreach efforts helped the client dominate search results.

--- a/src/content/cases/restaurant-ppc-success.md
+++ b/src/content/cases/restaurant-ppc-success.md
@@ -1,0 +1,7 @@
+---
+title: "Restaurant PPC Success"
+summary: "For a local restaurant, we implemented a targeted PPC campaign that resulted in a 50% increase in website traffic and a 25% increase in sales."
+link: "https://google.com"
+---
+
+Our team analysed the client's local market and crafted high-converting ad copy. Continuous optimisation ensured that ads reached the right diners at the right time.

--- a/src/content/cases/retail-social-campaign.md
+++ b/src/content/cases/retail-social-campaign.md
@@ -1,0 +1,7 @@
+---
+title: "Retail Social Campaign"
+summary: "For a national retail chain, we created a social media marketing campaign that increased followers by 25% and generated a 20% increase in online sales."
+link: "https://google.com"
+---
+
+By blending organic content with targeted ads, we built a community around the brand and drove consistent engagement that translated into revenue.

--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -13,6 +13,16 @@ const blogCollection = defineCollection({
   }),
 });
 
+const caseCollection = defineCollection({
+  type: 'content',
+  schema: z.object({
+    title: z.string(),
+    summary: z.string(),
+    link: z.string().url(),
+  }),
+});
+
 export const collections = {
   blog: blogCollection,
+  cases: caseCollection,
 };

--- a/src/pages/case-studies/[slug].astro
+++ b/src/pages/case-studies/[slug].astro
@@ -1,0 +1,39 @@
+---
+import MainLayout from "../../layouts/MainLayout.astro";
+import { getEntry } from 'astro:content';
+
+const { slug } = Astro.params;
+
+if (!slug) {
+  throw new Error('Slug is required');
+}
+
+const entry = await getEntry('cases', slug);
+
+if (!entry) {
+  return Astro.redirect('/404');
+}
+
+const { Content } = await entry.render();
+---
+<MainLayout title={entry.data.title}>
+    <main class="space-y-40 mb-40 pt-24">
+        <section class="bg-white">
+            <div class="gap-16 items-center py-8 px-4 mx-auto max-w-screen-xl lg:grid lg:grid-cols-1 lg:py-16 lg:px-3">
+                <div class="font-light text-gray-500 sm:text-lg">
+                    <a href="/case-studies" class="inline-flex items-center font-medium text-black hover:text-orange my-4">
+                        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" class="h-6 w-6">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 16l-4-4m0 0l4-4m-4 4h18" />
+                        </svg>
+                        <span class="ml-1 font-bold text-lg">All Case Studies</span>
+                    </a>
+                    <h2 class="mb-4 text-4xl tracking-tight font-extrabold text-gray-900">{entry.data.title}</h2>
+                    <p class="mb-6">{entry.data.summary}</p>
+                    <div class="content">
+                        <Content />
+                    </div>
+                </div>
+            </div>
+        </section>
+    </main>
+</MainLayout>

--- a/src/pages/case-studies/[slug].astro
+++ b/src/pages/case-studies/[slug].astro
@@ -17,23 +17,47 @@ if (!entry) {
 const { Content } = await entry.render();
 ---
 <MainLayout title={entry.data.title}>
-    <main class="space-y-40 mb-40 pt-24">
-        <section class="bg-white">
-            <div class="gap-16 items-center py-8 px-4 mx-auto max-w-screen-xl lg:grid lg:grid-cols-1 lg:py-16 lg:px-3">
-                <div class="font-light text-gray-500 sm:text-lg">
-                    <a href="/case-studies" class="inline-flex items-center font-medium text-black hover:text-orange my-4">
-                        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" class="h-6 w-6">
-                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 16l-4-4m0 0l4-4m-4 4h18" />
-                        </svg>
-                        <span class="ml-1 font-bold text-lg">All Case Studies</span>
-                    </a>
-                    <h2 class="mb-4 text-4xl tracking-tight font-extrabold text-gray-900">{entry.data.title}</h2>
-                    <p class="mb-6">{entry.data.summary}</p>
-                    <div class="content">
-                        <Content />
-                    </div>
-                </div>
-            </div>
-        </section>
-    </main>
+  <main class="space-y-40 mb-40 pt-24">
+    <!-- Hero -->
+    <section class="bg-white">
+      <div class="gap-16 items-center py-8 px-4 mx-auto max-w-screen-xl lg:grid lg:grid-cols-1 lg:py-16 lg:px-3">
+        <div class="font-light text-gray-500 sm:text-lg">
+          <a href="/case-studies" class="inline-flex items-center font-medium text-black hover:text-orange my-4">
+            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" class="h-6 w-6">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 16l-4-4m0 0l4-4m-4 4h18" />
+            </svg>
+            <span class="ml-1 font-bold text-lg">All Case Studies</span>
+          </a>
+          <h2 class="mb-4 text-4xl tracking-tight font-extrabold text-gray-900 intersect-once intersect:motion-preset-slide-up">{entry.data.title}</h2>
+          <p class="mb-6 intersect-once intersect:motion-preset-slide-up motion-delay-[.1s]">{entry.data.summary}</p>
+          <a href={entry.data.link} class="btn-primary inline-flex items-center gap-2 intersect-once intersect:motion-preset-slide-up motion-delay-[.2s]" target="_blank" rel="noopener noreferrer">
+            Visit Project
+            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" class="h-5 w-5">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 4h16v16M4 20L20 4" />
+            </svg>
+          </a>
+        </div>
+      </div>
+    </section>
+
+    <!-- Overview -->
+    <section class="bg-white">
+      <div class="gap-16 items-center py-8 px-4 mx-auto max-w-screen-xl lg:grid lg:grid-cols-2 lg:py-16 lg:px-3">
+        <div class="font-light text-gray-500 sm:text-lg">
+          <h3 class="mb-4 text-2xl font-bold text-gray-900 intersect-once intersect:motion-preset-slide-up">Overview</h3>
+          <div class="content intersect-once intersect:motion-preset-slide-up motion-delay-[.1s]">
+            <Content />
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- Results -->
+    <section class="bg-dark text-white">
+      <div class="py-16 px-4 mx-auto max-w-screen-xl lg:px-3">
+        <h3 class="mb-4 text-2xl font-bold intersect-once intersect:motion-preset-slide-up">Results</h3>
+        <p class="intersect-once intersect:motion-preset-slide-up motion-delay-[.1s]">{entry.data.summary}</p>
+      </div>
+    </section>
+  </main>
 </MainLayout>

--- a/src/pages/case-studies/index.astro
+++ b/src/pages/case-studies/index.astro
@@ -1,0 +1,22 @@
+---
+import MainLayout from "../../layouts/MainLayout.astro";
+import CaseCard from "../../components/ui/CaseCard.astro";
+import { getCollection } from 'astro:content';
+
+const caseStudies = await getCollection('cases');
+---
+<MainLayout title="Case Studies">
+    <main class="space-y-20">
+        <div class="py-8 px-4 mx-auto max-w-screen-xl lg:py-16 lg:px-3">
+            <div class="mx-auto max-w-screen-sm text-center lg:mb-16 mb-8">
+                <h2 class="mb-4 text-3xl lg:text-4xl tracking-tight font-extrabold">Case Studies</h2>
+                <p class="font-light sm:text-xl">Explore real-life examples of our proven digital marketing success.</p>
+            </div>
+            <div class="grid gap-8 lg:grid-cols-3">
+                {caseStudies.map(cs => (
+                    <CaseCard summary={cs.data.summary} link={'/case-studies/' + cs.slug} />
+                ))}
+            </div>
+        </div>
+    </main>
+</MainLayout>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,5 +1,5 @@
 ---
-// import Cases from "../components/sections/Cases.astro";
+import Cases from "../components/sections/Cases.astro";
 import Contact from "../components/sections/Contact.astro";
 import Hero from "../components/sections/Hero.astro";
 import Process from "../components/sections/Process.astro";
@@ -19,7 +19,7 @@ import MainLayout from "../layouts/MainLayout.astro";
   <Sponsors />
   <Services />
   <Proposal />
-  <!-- <Cases /> -->
+  <Cases />
   <Process />
   <Testimonials />
   <Contact />


### PR DESCRIPTION
## Summary
- add `cases` content collection
- create case studies markdown files
- add `CaseCard` component and updated `Cases` section to pull data from content
- create listing and detail pages for case studies
- show case studies on home page

## Testing
- `npm run build` *(fails: astro not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847756dfa2c8322ac608d1e038082ba