### PR TITLE
Add cross-device persistence via Vercel KV

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@tailwindcss/vite": "^4.1.4",
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
+        "@vercel/kv": "^1.0.1",
         "astro": "^5.7.9",
         "astro-heroicons": "^2.1.5-1",
         "astro-navbar": "^2.3.7",
@@ -2871,6 +2872,17 @@
       "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
       "license": "ISC"
     },
+    "node_modules/@upstash/redis": {
+      "version": "1.38.0",
+      "resolved": "https://registry.npmjs.org/@upstash/redis/-/redis-1.38.0.tgz",
+      "integrity": "sha512-wu+dZBptlLy0+MCUEoHmzrY/TnmgDey3+c7EbIGwrLqAvkP8yi5MWZHYGIFtAygmL4Bkz2TdFu+eU0vFPncIcg==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "uncrypto": "^0.1.3"
+      }
+    },
     "node_modules/@vercel/analytics": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/@vercel/analytics/-/analytics-1.5.0.tgz",
@@ -2914,6 +2926,28 @@
       "resolved": "https://registry.npmjs.org/@vercel/edge/-/edge-1.2.1.tgz",
       "integrity": "sha512-1++yncEyIAi68D3UEOlytYb1IUcIulMWdoSzX2h9LuSeeyR7JtaIgR8DcTQ6+DmYOQn+5MCh6LY+UmK6QBByNA==",
       "license": "Apache-2.0"
+    },
+    "node_modules/@vercel/kv": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@vercel/kv/-/kv-1.0.1.tgz",
+      "integrity": "sha512-uTKddsqVYS2GRAM/QMNNXCTuw9N742mLoGRXoNDcyECaxEXvIHG0dEY+ZnYISV4Vz534VwJO+64fd9XeSggSKw==",
+      "deprecated": "Vercel KV is deprecated. If you had an existing KV store, it should have moved to Upstash Redis which you will see under Vercel Integrations. For new projects, install a Redis integration from Vercel Marketplace: https://vercel.com/marketplace?category=storage&search=redis",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@upstash/redis": "1.25.1"
+      },
+      "engines": {
+        "node": ">=14.6"
+      }
+    },
+    "node_modules/@vercel/kv/node_modules/@upstash/redis": {
+      "version": "1.25.1",
+      "resolved": "https://registry.npmjs.org/@upstash/redis/-/redis-1.25.1.tgz",
+      "integrity": "sha512-ACj0GhJ4qrQyBshwFgPod6XufVEfKX2wcaihsEvSdLYnY+m+pa13kGt1RXm/yTHKf4TQi/Dy2A8z/y6WUEOmlg==",
+      "license": "MIT",
+      "dependencies": {
+        "crypto-js": "^4.2.0"
+      }
     },
     "node_modules/@vercel/nft": {
       "version": "0.29.2",
@@ -3878,6 +3912,12 @@
       "dependencies": {
         "uncrypto": "^0.1.3"
       }
+    },
+    "node_modules/crypto-js": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.2.0.tgz",
+      "integrity": "sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q==",
+      "license": "MIT"
     },
     "node_modules/css-tree": {
       "version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@tailwindcss/vite": "^4.1.4",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
+    "@vercel/kv": "^1.0.1",
     "astro": "^5.7.9",
     "astro-heroicons": "^2.1.5-1",
     "astro-navbar": "^2.3.7",

--- a/src/components/SchedulePlanner.tsx
+++ b/src/components/SchedulePlanner.tsx
@@ -273,6 +273,14 @@ export default function SchedulePlanner() {
   const [overrides, setOverrides] = useState<Record<string, number>>({});
   const [holidays, setHolidays] = useState<Set<string>>(new Set());
 
+  const [isLoaded, setIsLoaded] = useState(false);
+  const [saveStatus, setSaveStatus] = useState<"idle" | "saving" | "saved" | "error">("idle");
+  const [showPwPrompt, setShowPwPrompt] = useState(false);
+  const [pwInput, setPwInput] = useState("");
+  const isDirtyRef = useRef(false);
+  const saveTimerRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
+  const pendingPayloadRef = useRef<{ overrides: Record<string, number>; holidays: string[] } | null>(null);
+
   useEffect(() => {
     const link = document.createElement("link");
     link.rel = "stylesheet";
@@ -281,15 +289,72 @@ export default function SchedulePlanner() {
     return () => { document.head.removeChild(link); };
   }, []);
 
+  // Load saved state from API on mount
+  useEffect(() => {
+    fetch("/api/schedule")
+      .then(r => r.json())
+      .then((data: { overrides: Record<string, number>; holidays: string[] }) => {
+        if (data.overrides) setOverrides(data.overrides);
+        if (data.holidays) setHolidays(new Set(data.holidays));
+      })
+      .catch(() => {})
+      .finally(() => setIsLoaded(true));
+  }, []);
+
+  // Debounced auto-save — only fires after load and on user edits
+  useEffect(() => {
+    if (!isLoaded || !isDirtyRef.current) return;
+    clearTimeout(saveTimerRef.current);
+    const payload = { overrides, holidays: Array.from(holidays) };
+    saveTimerRef.current = setTimeout(() => doSave(payload), 600);
+    return () => clearTimeout(saveTimerRef.current);
+  }, [overrides, holidays, isLoaded]);
+
+  async function doSave(
+    payload: { overrides: Record<string, number>; holidays: string[] },
+    pw?: string,
+  ) {
+    setSaveStatus("saving");
+    pendingPayloadRef.current = payload;
+    const storedPw = pw ?? (typeof localStorage !== "undefined" ? localStorage.getItem("sp-password") ?? "" : "");
+    const headers: Record<string, string> = { "Content-Type": "application/json" };
+    if (storedPw) headers["x-schedule-password"] = storedPw;
+    try {
+      const res = await fetch("/api/schedule", { method: "POST", headers, body: JSON.stringify(payload) });
+      if (res.status === 401) {
+        setSaveStatus("error");
+        setShowPwPrompt(true);
+        return;
+      }
+      if (res.ok) {
+        isDirtyRef.current = false;
+        setSaveStatus("saved");
+        setTimeout(() => setSaveStatus("idle"), 2000);
+      } else {
+        setSaveStatus("error");
+      }
+    } catch {
+      setSaveStatus("error");
+    }
+  }
+
+  function handlePwSubmit() {
+    localStorage.setItem("sp-password", pwInput);
+    setShowPwPrompt(false);
+    if (pendingPayloadRef.current) doSave(pendingPayloadRef.current, pwInput);
+    setPwInput("");
+  }
+
   const { year, month } = MONTHS_LIST[sel];
   const { firstDay, days, bonusDays, totalHours, effectiveTarget, holidayCount } = getMonthData(year, month, overrides, holidays);
   const allBonus = MONTHS_LIST.map(m => getMonthData(m.year, m.month, overrides, holidays).bonusDays.length);
   const maxBonus = Math.max(...allBonus, 1);
   const hasOverridesThisMonth = days.some(d => d.isOverridden);
 
-  const handleSave = (key: string, h: number) => setOverrides(o => ({ ...o, [key]: h }));
-  const handleReset = (key: string) => setOverrides(o => { const n = { ...o }; delete n[key]; return n; });
+  const handleSave = (key: string, h: number) => { isDirtyRef.current = true; setOverrides(o => ({ ...o, [key]: h })); };
+  const handleReset = (key: string) => { isDirtyRef.current = true; setOverrides(o => { const n = { ...o }; delete n[key]; return n; }); };
   const handleToggleHoliday = (key: string) => {
+    isDirtyRef.current = true;
     setHolidays(prev => {
       const next = new Set(prev);
       if (next.has(key)) next.delete(key); else next.add(key);
@@ -297,6 +362,7 @@ export default function SchedulePlanner() {
     });
   };
   const resetMonth = () => {
+    isDirtyRef.current = true;
     const keys = days.filter(d => d.isOverridden).map(d => dayKey(year, month, d.day));
     setOverrides(o => { const n = { ...o }; keys.forEach(k => delete n[k]); return n; });
   };
@@ -315,10 +381,54 @@ export default function SchedulePlanner() {
       margin: "0 auto",
     }}>
 
+      {/* Password prompt overlay */}
+      {showPwPrompt && (
+        <div style={{
+          position: "fixed", inset: 0, background: "rgba(0,0,0,0.35)", zIndex: 1000,
+          display: "flex", alignItems: "center", justifyContent: "center",
+        }}>
+          <div style={{
+            background: "#fff", borderRadius: 12, padding: 24, width: 280,
+            boxShadow: "0 12px 40px rgba(0,0,0,0.2)", fontFamily: "'DM Mono', monospace",
+          }}>
+            <div style={{ fontSize: 13, fontWeight: 600, color: "#1a1a2e", marginBottom: 6 }}>Password required</div>
+            <div style={{ fontSize: 10, color: "#aaa", marginBottom: 14 }}>Enter the password to save changes.</div>
+            <input
+              autoFocus
+              type="password"
+              value={pwInput}
+              onChange={e => setPwInput(e.target.value)}
+              onKeyDown={e => e.key === "Enter" && handlePwSubmit()}
+              placeholder="Password"
+              style={{
+                width: "100%", padding: "8px 10px", fontSize: 12, fontFamily: "inherit",
+                border: "1px solid #d8d4cc", borderRadius: 6, outline: "none",
+                color: "#1a1a2e", boxSizing: "border-box", marginBottom: 12,
+              }}
+            />
+            <div style={{ display: "flex", gap: 8 }}>
+              <button onClick={handlePwSubmit} style={{
+                flex: 1, padding: "8px 0", fontSize: 11, fontFamily: "inherit",
+                background: "#1a1a2e", color: "#fff", border: "none", borderRadius: 6, cursor: "pointer", fontWeight: 600,
+              }}>Save</button>
+              <button onClick={() => { setShowPwPrompt(false); setPwInput(""); setSaveStatus("idle"); }} style={{
+                padding: "8px 14px", fontSize: 11, fontFamily: "inherit",
+                background: "#f5f0e8", color: "#888", border: "1px solid #e0d8cc", borderRadius: 6, cursor: "pointer",
+              }}>Cancel</button>
+            </div>
+          </div>
+        </div>
+      )}
+
       {/* Header */}
       <div style={{ display: "flex", justifyContent: "space-between", alignItems: "flex-start", gap: 12, marginBottom: 16, borderBottom: "1px solid #e4e0d8", paddingBottom: 14, flexWrap: "wrap" }}>
         <div style={{ minWidth: 0 }}>
-          <h1 style={{ fontFamily: "'Syne', sans-serif", fontSize: 19, fontWeight: 800, margin: 0, color: "#1a1a2e", letterSpacing: "-0.02em" }}>Volunteer Hours</h1>
+          <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+            <h1 style={{ fontFamily: "'Syne', sans-serif", fontSize: 19, fontWeight: 800, margin: 0, color: "#1a1a2e", letterSpacing: "-0.02em" }}>Volunteer Hours</h1>
+            {saveStatus === "saving" && <span style={{ fontSize: 8.5, color: "#bbb", letterSpacing: "0.05em" }}>saving…</span>}
+            {saveStatus === "saved"  && <span style={{ fontSize: 8.5, color: "#2baa65", letterSpacing: "0.05em" }}>saved ✓</span>}
+            {saveStatus === "error" && !showPwPrompt && <span style={{ fontSize: 8.5, color: "#c04040", letterSpacing: "0.05em" }}>error saving</span>}
+          </div>
           <p style={{ fontSize: 9, color: "#bbb", margin: "3px 0 0", letterSpacing: "0.08em", textTransform: "uppercase" }}>Aug 2026 – Aug 2027 · tap any day to edit</p>
         </div>
         <div style={{ display: "flex", gap: 10, flexShrink: 0 }}>

--- a/src/pages/api/schedule.ts
+++ b/src/pages/api/schedule.ts
@@ -1,0 +1,42 @@
+import type { APIRoute } from "astro";
+import { kv } from "@vercel/kv";
+
+const KV_KEY = "schedule-planner-state";
+const PASSWORD = import.meta.env.SCHEDULE_PASSWORD;
+
+export const GET: APIRoute = async () => {
+  try {
+    const data = await kv.get<{ overrides: Record<string, number>; holidays: string[] }>(KV_KEY);
+    return new Response(JSON.stringify(data ?? { overrides: {}, holidays: [] }), {
+      headers: { "Content-Type": "application/json" },
+    });
+  } catch {
+    return new Response(JSON.stringify({ overrides: {}, holidays: [] }), {
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+};
+
+export const POST: APIRoute = async ({ request }) => {
+  if (PASSWORD) {
+    const auth = request.headers.get("x-schedule-password");
+    if (auth !== PASSWORD) {
+      return new Response(JSON.stringify({ error: "Unauthorized" }), {
+        status: 401,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+  }
+  try {
+    const body = await request.json();
+    await kv.set(KV_KEY, body);
+    return new Response(JSON.stringify({ ok: true }), {
+      headers: { "Content-Type": "application/json" },
+    });
+  } catch {
+    return new Response(JSON.stringify({ error: "Failed to save" }), {
+      status: 500,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+};


### PR DESCRIPTION
- Install @vercel/kv
- Add GET/POST API endpoint at /api/schedule backed by Vercel KV
- Load saved state from API on mount
- Debounced auto-save (600ms) on every user edit
- Optional password protection via SCHEDULE_PASSWORD env var
- Show saving/saved/error status in header
- Password prompt modal on 401, stores password in localStorage

https://claude.ai/code/session_01EjcVdyTAxCPrMo5pBwD8az