### PR TITLE
Move password auth to page level via cookie

### DIFF
--- a/src/components/SchedulePlanner.tsx
+++ b/src/components/SchedulePlanner.tsx
@@ -275,11 +275,8 @@ export default function SchedulePlanner() {
 
   const [isLoaded, setIsLoaded] = useState(false);
   const [saveStatus, setSaveStatus] = useState<"idle" | "saving" | "saved" | "error">("idle");
-  const [showPwPrompt, setShowPwPrompt] = useState(false);
-  const [pwInput, setPwInput] = useState("");
   const isDirtyRef = useRef(false);
   const saveTimerRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
-  const pendingPayloadRef = useRef<{ overrides: Record<string, number>; holidays: string[] } | null>(null);
 
   useEffect(() => {
     const link = document.createElement("link");
@@ -310,22 +307,14 @@ export default function SchedulePlanner() {
     return () => clearTimeout(saveTimerRef.current);
   }, [overrides, holidays, isLoaded]);
 
-  async function doSave(
-    payload: { overrides: Record<string, number>; holidays: string[] },
-    pw?: string,
-  ) {
+  async function doSave(payload: { overrides: Record<string, number>; holidays: string[] }) {
     setSaveStatus("saving");
-    pendingPayloadRef.current = payload;
-    const storedPw = pw ?? (typeof localStorage !== "undefined" ? localStorage.getItem("sp-password") ?? "" : "");
-    const headers: Record<string, string> = { "Content-Type": "application/json" };
-    if (storedPw) headers["x-schedule-password"] = storedPw;
     try {
-      const res = await fetch("/api/schedule", { method: "POST", headers, body: JSON.stringify(payload) });
-      if (res.status === 401) {
-        setSaveStatus("error");
-        setShowPwPrompt(true);
-        return;
-      }
+      const res = await fetch("/api/schedule", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+      });
       if (res.ok) {
         isDirtyRef.current = false;
         setSaveStatus("saved");
@@ -336,13 +325,6 @@ export default function SchedulePlanner() {
     } catch {
       setSaveStatus("error");
     }
-  }
-
-  function handlePwSubmit() {
-    localStorage.setItem("sp-password", pwInput);
-    setShowPwPrompt(false);
-    if (pendingPayloadRef.current) doSave(pendingPayloadRef.current, pwInput);
-    setPwInput("");
   }
 
   const { year, month } = MONTHS_LIST[sel];
@@ -381,45 +363,6 @@ export default function SchedulePlanner() {
       margin: "0 auto",
     }}>
 
-      {/* Password prompt overlay */}
-      {showPwPrompt && (
-        <div style={{
-          position: "fixed", inset: 0, background: "rgba(0,0,0,0.35)", zIndex: 1000,
-          display: "flex", alignItems: "center", justifyContent: "center",
-        }}>
-          <div style={{
-            background: "#fff", borderRadius: 12, padding: 24, width: 280,
-            boxShadow: "0 12px 40px rgba(0,0,0,0.2)", fontFamily: "'DM Mono', monospace",
-          }}>
-            <div style={{ fontSize: 13, fontWeight: 600, color: "#1a1a2e", marginBottom: 6 }}>Password required</div>
-            <div style={{ fontSize: 10, color: "#aaa", marginBottom: 14 }}>Enter the password to save changes.</div>
-            <input
-              autoFocus
-              type="password"
-              value={pwInput}
-              onChange={e => setPwInput(e.target.value)}
-              onKeyDown={e => e.key === "Enter" && handlePwSubmit()}
-              placeholder="Password"
-              style={{
-                width: "100%", padding: "8px 10px", fontSize: 12, fontFamily: "inherit",
-                border: "1px solid #d8d4cc", borderRadius: 6, outline: "none",
-                color: "#1a1a2e", boxSizing: "border-box", marginBottom: 12,
-              }}
-            />
-            <div style={{ display: "flex", gap: 8 }}>
-              <button onClick={handlePwSubmit} style={{
-                flex: 1, padding: "8px 0", fontSize: 11, fontFamily: "inherit",
-                background: "#1a1a2e", color: "#fff", border: "none", borderRadius: 6, cursor: "pointer", fontWeight: 600,
-              }}>Save</button>
-              <button onClick={() => { setShowPwPrompt(false); setPwInput(""); setSaveStatus("idle"); }} style={{
-                padding: "8px 14px", fontSize: 11, fontFamily: "inherit",
-                background: "#f5f0e8", color: "#888", border: "1px solid #e0d8cc", borderRadius: 6, cursor: "pointer",
-              }}>Cancel</button>
-            </div>
-          </div>
-        </div>
-      )}
-
       {/* Header */}
       <div style={{ display: "flex", justifyContent: "space-between", alignItems: "flex-start", gap: 12, marginBottom: 16, borderBottom: "1px solid #e4e0d8", paddingBottom: 14, flexWrap: "wrap" }}>
         <div style={{ minWidth: 0 }}>
@@ -427,7 +370,7 @@ export default function SchedulePlanner() {
             <h1 style={{ fontFamily: "'Syne', sans-serif", fontSize: 19, fontWeight: 800, margin: 0, color: "#1a1a2e", letterSpacing: "-0.02em" }}>Volunteer Hours</h1>
             {saveStatus === "saving" && <span style={{ fontSize: 8.5, color: "#bbb", letterSpacing: "0.05em" }}>saving…</span>}
             {saveStatus === "saved"  && <span style={{ fontSize: 8.5, color: "#2baa65", letterSpacing: "0.05em" }}>saved ✓</span>}
-            {saveStatus === "error" && !showPwPrompt && <span style={{ fontSize: 8.5, color: "#c04040", letterSpacing: "0.05em" }}>error saving</span>}
+            {saveStatus === "error" && <span style={{ fontSize: 8.5, color: "#c04040", letterSpacing: "0.05em" }}>error saving</span>}
           </div>
           <p style={{ fontSize: 9, color: "#bbb", margin: "3px 0 0", letterSpacing: "0.08em", textTransform: "uppercase" }}>Aug 2026 – Aug 2027 · tap any day to edit</p>
         </div>

--- a/src/pages/api/schedule.ts
+++ b/src/pages/api/schedule.ts
@@ -2,7 +2,6 @@ import type { APIRoute } from "astro";
 import { kv } from "@vercel/kv";
 
 const KV_KEY = "schedule-planner-state";
-const PASSWORD = import.meta.env.SCHEDULE_PASSWORD;
 
 export const GET: APIRoute = async () => {
   try {
@@ -18,15 +17,6 @@ export const GET: APIRoute = async () => {
 };
 
 export const POST: APIRoute = async ({ request }) => {
-  if (PASSWORD) {
-    const auth = request.headers.get("x-schedule-password");
-    if (auth !== PASSWORD) {
-      return new Response(JSON.stringify({ error: "Unauthorized" }), {
-        status: 401,
-        headers: { "Content-Type": "application/json" },
-      });
-    }
-  }
   try {
     const body = await request.json();
     await kv.set(KV_KEY, body);

--- a/src/pages/sp/index.astro
+++ b/src/pages/sp/index.astro
@@ -1,5 +1,26 @@
 ---
 import SchedulePlanner from "../../components/SchedulePlanner";
+
+const PASSWORD = import.meta.env.SCHEDULE_PASSWORD;
+const COOKIE_NAME = "sp-auth";
+
+const isAuthed = !PASSWORD || Astro.cookies.get(COOKIE_NAME)?.value === "ok";
+
+let error = false;
+if (Astro.request.method === "POST") {
+  const form = await Astro.request.formData();
+  if (form.get("password") === PASSWORD) {
+    Astro.cookies.set(COOKIE_NAME, "ok", {
+      httpOnly: true,
+      secure: true,
+      sameSite: "strict",
+      maxAge: 60 * 60 * 24 * 30,
+      path: "/",
+    });
+    return Astro.redirect(Astro.url.pathname);
+  }
+  error = true;
+}
 ---
 
 <!DOCTYPE html>
@@ -14,6 +35,28 @@ import SchedulePlanner from "../../components/SchedulePlanner";
     </style>
   </head>
   <body>
-    <SchedulePlanner client:load />
+    {isAuthed ? (
+      <SchedulePlanner client:load />
+    ) : (
+      <div style="min-height:100vh;display:flex;align-items:center;justify-content:center;font-family:'DM Mono',monospace;background:#f6f5f1;">
+        <div style="background:#fff;border-radius:14px;padding:32px 28px;width:300px;box-shadow:0 4px 24px rgba(0,0,0,0.08);border:1px solid #eae8e0;">
+          <div style="font-size:18px;font-weight:800;color:#1a1a2e;margin-bottom:4px;letter-spacing:-0.02em;">Volunteer Hours</div>
+          <div style="font-size:9px;color:#bbb;letter-spacing:0.08em;text-transform:uppercase;margin-bottom:24px;">Enter password to continue</div>
+          <form method="POST">
+            <input
+              type="password"
+              name="password"
+              autofocus
+              placeholder="Password"
+              style="width:100%;padding:9px 12px;font-size:12px;font-family:inherit;border:1px solid #d8d4cc;border-radius:7px;outline:none;color:#1a1a2e;margin-bottom:10px;"
+            />
+            {error && <div style="font-size:9.5px;color:#c04040;margin-bottom:10px;">Incorrect password.</div>}
+            <button type="submit" style="width:100%;padding:9px 0;font-size:11px;font-family:inherit;background:#1a1a2e;color:#fff;border:none;border-radius:7px;cursor:pointer;font-weight:600;letter-spacing:0.04em;">
+              Continue
+            </button>
+          </form>
+        </div>
+      </div>
+    )}
   </body>
 </html>


### PR DESCRIPTION
- Password gate on the entire /sp page using a 30-day httpOnly cookie
- Shows a minimal login form when SCHEDULE_PASSWORD env var is set
- Remove per-save password logic from React component and API
- Anyone who enters the correct password once can view and edit

https://claude.ai/code/session_01EjcVdyTAxCPrMo5pBwD8az