### PR TITLE
Move password auth to page level via cookie

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -4,7 +4,7 @@ export const onRequest = defineMiddleware(async (context, next) => {
   const host = context.request.headers.get("host") || "";
   const hostname = host.split(":")[0];
 
-  if (hostname === "sp.nudgetheweb.com" && !context.url.pathname.startsWith("/sp")) {
+  if (hostname === "sp.nudgetheweb.com" && !context.url.pathname.startsWith("/sp") && !context.url.pathname.startsWith("/api")) {
     return context.rewrite("/sp");
   }
 

--- a/src/pages/sp/index.astro
+++ b/src/pages/sp/index.astro
@@ -7,7 +7,8 @@ const COOKIE_NAME = "sp-auth";
 const isAuthed = !PASSWORD || Astro.cookies.get(COOKIE_NAME)?.value === "ok";
 
 let error = false;
-if (Astro.request.method === "POST") {
+const contentType = Astro.request.headers.get("content-type") ?? "";
+if (Astro.request.method === "POST" && contentType.includes("urlencoded")) {
   const form = await Astro.request.formData();
   if (form.get("password") === PASSWORD) {
     Astro.cookies.set(COOKIE_NAME, "ok", {


### PR DESCRIPTION
Middleware was rewriting all non-/sp paths on sp.nudgetheweb.com, including /api/schedule POSTs from the React component. The page then called formData() on a JSON request and crashed.

- Exclude /api paths from the subdomain rewrite in middleware
- Guard formData() with a content-type check as a safety net

https://claude.ai/code/session_01EjcVdyTAxCPrMo5pBwD8az