### PR TITLE
Fix subdomain routing to serve at root path

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,8 +1,7 @@
 import { defineMiddleware } from "astro:middleware";
 
 export const onRequest = defineMiddleware(async (context, next) => {
-  const host = context.request.headers.get("host") || "";
-  const hostname = host.split(":")[0];
+  const hostname = context.url.hostname;
 
   if (hostname === "sp.nudgetheweb.com" && !context.url.pathname.startsWith("/sp") && !context.url.pathname.startsWith("/api")) {
     return context.rewrite("/sp");

--- a/src/pages/sp/index.astro
+++ b/src/pages/sp/index.astro
@@ -18,7 +18,7 @@ if (Astro.request.method === "POST" && contentType.includes("urlencoded")) {
       maxAge: 60 * 60 * 24 * 30,
       path: "/",
     });
-    return Astro.redirect(Astro.url.pathname);
+    return Astro.redirect("/");
   }
   error = true;
 }


### PR DESCRIPTION
- Use context.url.hostname instead of parsing host header (more reliable on Vercel)
- Redirect to / after login instead of /sp so URL stays clean

https://claude.ai/code/session_01EjcVdyTAxCPrMo5pBwD8az